### PR TITLE
Bug fixes to `from_counts` and `logical_decomposition` in `LogicalStatevector` and to `LogicalDensityMatrix`'s iterable constructor.

### DIFF
--- a/LogicalQ/Logical.py
+++ b/LogicalQ/Logical.py
@@ -1637,21 +1637,19 @@ class LogicalStatevector(Statevector):
                 binary = ""
                 if all([char in ["0", "1"] for char in outcome_raw]):
                     binary = outcome_raw
-                    # outcomes.append(outcome_raw[1:1+label[0]])
                 elif outcome_raw.startswith("0b"):
                     binary = outcome_raw[2:]
-                    # outcomes.append(outcome_raw[3:3+label[0]])
                 elif outcome_raw.startswith("0x"):
                     binary = str(bin(int(outcome_raw, 16)))[2:]
-                    # outcomes.append(binary[1:1+label[0]])
                 else:
                     raise ValueError("Could not resolve count format")
-                if len(binary) < label[0]: # handling weird edge case
+
+                # If binary string is short (e.g. 0b0 or 0x0), pad to have length equalling number of data qubits
+                if len(binary) < label[0]:
                     binary = "0"*(label[0] - len(binary)) + binary
                     outcomes.append(binary)
                 else:
                     outcomes.append(binary[1:1+label[0]])
-
         elif basis == "logical":
             # @TODO - make sure this is correct
             for outcome_raw in outcomes_raw:
@@ -1716,7 +1714,7 @@ class LogicalStatevector(Statevector):
 
             alpha = np.vdot(self.data, lsv_0L.data)
             beta = np.vdot(self.data, lsv_1L.data)
-            delta = np.sqrt(1 - np.pow(np.abs(alpha),2) + np.pow(np.abs(beta),2))
+            delta = np.sqrt(1 - np.pow(np.abs(alpha), 2) + np.pow(np.abs(beta), 2))
 
             self._logical_decomposition = np.array([alpha, beta, delta])
             real_part = np.real(self._logical_decomposition)
@@ -1816,7 +1814,7 @@ class LogicalDensityMatrix(DensityMatrix):
             raise NotImplementedError("LogicalDensityMatrix construction from QuantumCircuit is not yet supported; please provide a LogicalCircuit or an amplitude iterable")
         elif hasattr(data, "__iter__"):
             if not (np.log2(len(data)).is_integer() and data.shape == (len(data), len(data))):
-                raise ValueError("LogicalDensityMatrix data must be a square matrix whose dimention is a power of 2.")
+                raise ValueError("LogicalDensityMatrix data must be a square matrix whose dimension is a power of 2.")
             if n_logical_qubits and label and stabilizer_tableau:
                 self.logical_circuit = None
                 self.n_logical_qubits = n_logical_qubits


### PR DESCRIPTION
Made the following bug fixes:

1. Properly parse input strings to the `from_counts` method in `LogicalStatevector`. Hex strings and the 0 string (i.e. `'0b0'`) were not handled properly previously, leading to an error.
2. Fix the calculation of `delta` in the `logical_decomposition` method of `LogicalStatevector`. The square root should be positioned over the entire expression, and we need to take the absolute square since the coefficients `alpha` and `beta` are in general complex.
3. Properly set separately the real and imaginary parts of `_logical_decomposition` to zero if each is below `atol`, rather than setting the entire value to zero if its modulus is below `atol`.
4. Add a check to `LogicalDensityMatrix`'s iterable constructor to ensure the input is a square matrix whose dimension is a power of 2.